### PR TITLE
gameForJoinCode GraphQL query

### DIFF
--- a/api/app/graphql/types/query_type.rb
+++ b/api/app/graphql/types/query_type.rb
@@ -2,7 +2,12 @@
 
 module Types
   class QueryType < Types::BaseObject
-    # Add root-level fields here.
-    # They will be entry points for queries on your schema.
+    field :game_for_join_code, Types::GameType do
+      argument :join_code, String, required: true
+    end
+
+    def game_for_join_code(join_code:)
+      Game.find_by!(join_code: join_code)
+    end
   end
 end

--- a/api/schema.graphql
+++ b/api/schema.graphql
@@ -28,5 +28,6 @@ type Mutation {
 }
 
 type Query {
+  gameForJoinCode(joinCode: String!): Game
   id: String!
 }

--- a/api/schema.json
+++ b/api/schema.json
@@ -236,6 +236,35 @@
           "possibleTypes": null,
           "fields": [
             {
+              "name": "gameForJoinCode",
+              "description": null,
+              "type": {
+                "kind": "OBJECT",
+                "name": "Game",
+                "ofType": null
+              },
+              "isDeprecated": false,
+              "deprecationReason": null,
+              "args": [
+                {
+                  "name": "joinCode",
+                  "description": null,
+                  "type": {
+                    "kind": "NON_NULL",
+                    "name": null,
+                    "ofType": {
+                      "kind": "SCALAR",
+                      "name": "String",
+                      "ofType": null
+                    }
+                  },
+                  "defaultValue": null,
+                  "isDeprecated": false,
+                  "deprecationReason": null
+                }
+              ]
+            },
+            {
               "name": "id",
               "description": null,
               "type": {

--- a/api/test/graphql/types/query_type_test.rb
+++ b/api/test/graphql/types/query_type_test.rb
@@ -1,0 +1,29 @@
+# frozen_string_literal: true
+
+require "test_helper"
+
+module Types
+  class QueryTypeTest < ActiveSupport::TestCase
+    test "returns a game for a join code" do
+      game = create(:game)
+
+      query = <<~GQL
+        query GameForJoinCode($joinCode: String!) {
+          gameForJoinCode(joinCode: $joinCode) {
+            id
+            name
+          }
+        }
+      GQL
+
+      result = TriviaSchema.execute(query: query, variables: { joinCode: game.join_code })
+
+      assert_nil(result["errors"])
+      assert_nil(result.dig("data", "errors"))
+
+      returned_game = result.dig("data", "gameForJoinCode")
+
+      assert_equal({ "id" => game.to_param, "name" => game.name }, returned_game)
+    end
+  end
+end


### PR DESCRIPTION
- Adds a new `gameForJoinCode` query to the base `Types::QueryType`

Check it out in `localhost:3000/graphiql`:

<img width="1031" alt="Screen Shot 2022-03-20 at 4 55 12 PM" src="https://user-images.githubusercontent.com/302063/159191489-bb58175d-d09c-4ea4-8891-9df265e3d13a.png">

